### PR TITLE
Adds some text before js loads

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -23,7 +23,7 @@
     <meta name="theme-color" content="#fff">
   </head>
   <body>
-    <div id='app'></div>
+    <div id='app'>JavaScript is needed to view this page</div>
   </body>
   <script src='bundle.js'></script>
   <script>
@@ -33,7 +33,7 @@
         return;
       }
 
-      navigator.serviceWorker.register('service-worker.js')
+      navigator.serviceWorker.register('/service-worker.js')
         .then(registration => console.log('Registered at scope:', registration.scope))
         .catch(err => console.log('Registration failed', err));
     })();


### PR DESCRIPTION
A progressive web app should show something if the js doesnt load.  The
problem is that our site takes too long to load and the text is shown
for a half a second before the js loads.  One of the next things I am
  planning on tackling is load speed so maybe that will correct it.  If not
  I will have to figure out a way to do it with just basic html.

  Also this changes the path of the service worker from relative to
  absolute needed for deployment.