### PR TITLE
Page speed optimize

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -25,8 +25,8 @@
   <body>
     <div id='app'>JavaScript is needed to view this page</div>
   </body>
-  <script src='bundle.js'></script>
-  <script>
+  <script src='bundle.js' async></script>
+  <script async>
     (function() {
       if (!('serviceWorker' in navigator)) {
         console.log('Service worker not supported');

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -10,7 +10,7 @@ import { InMemoryCache } from 'apollo-cache-inmemory'
 
 
 // APOLLO SERVER CONNECTION - create a link that connects the Apollo Client to graphQL server
-const httpLink = new HttpLink({ uri: 'http://localhost:8080/graphql' });
+const httpLink = new HttpLink({ uri: '/graphql' });
 
 // Instantiate ApolloClient
 const client = new ApolloClient({

--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,7 @@ app.use((req, res, next) => {
   }
 });
 
+
 const typeDefs = `
   type Query {
     user(num: String!): User


### PR DESCRIPTION
By making both the bundle and service worker scripts async it allows the html to load quicker because anytime the browser hits a script tags it stops building the DOM and transfers control to that script.  By making both scripts async they load after the DOM is constructed.

This did not squash the error message about javascript from displaying so that is my next task.